### PR TITLE
fix: remove rlib from crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "usn"
 version = "1.0.2"
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 near-contract-standards = "=4.0.0-pre.7"


### PR DESCRIPTION
rlib is only needed when you need to import types exported from the library external to the crate and will not do any LTO.

With docker build,
Contract size with rlib: 432740
Contract size without: 366547